### PR TITLE
ci: Add prop sonar.test no sonar-project.properties

### DIFF
--- a/create-auth-challenge/sonar-project.properties
+++ b/create-auth-challenge/sonar-project.properties
@@ -8,6 +8,7 @@ sonar.organization=grupo-g03-4soat-fiap
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 #sonar.sources=.
+sonar.test=tests
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8

--- a/define-auth-challenge/sonar-project.properties
+++ b/define-auth-challenge/sonar-project.properties
@@ -8,6 +8,7 @@ sonar.organization=grupo-g03-4soat-fiap
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 #sonar.sources=.
+sonar.test=tests
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8

--- a/pre-signup/sonar-project.properties
+++ b/pre-signup/sonar-project.properties
@@ -8,6 +8,7 @@ sonar.organization=grupo-g03-4soat-fiap
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 #sonar.sources=.
+sonar.test=tests
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8

--- a/verify-auth-challenge/sonar-project.properties
+++ b/verify-auth-challenge/sonar-project.properties
@@ -8,6 +8,7 @@ sonar.organization=grupo-g03-4soat-fiap
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 #sonar.sources=.
+sonar.test=tests
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Adicionando propriedade `sonar.test` nos arquivos `sonar-project.properties` para que o Sonar não meça coverage dos arquivos jest dos testes unitários.